### PR TITLE
発表時に名前とアイコンを実行者のものを使う実装、レビューコメントの追加実装

### DIFF
--- a/src/commands/cem_publish.ts
+++ b/src/commands/cem_publish.ts
@@ -39,6 +39,7 @@ export default function() {
       }
       const challenger = await challengerRef.get()
       const challengerName = challenger.data()!.displayName
+      const iconUrl = challenger.data()!.iconUrl
       const blocks: Block[] = [
         {
           type: `section`,
@@ -83,6 +84,8 @@ export default function() {
         },
         blocks: blocks,
         channel: channel,
+        username: challengerName,
+        icon_url: iconUrl,
       }
       return app.client.chat.postMessage(msg).catch(err => {
         throw new Error(err)

--- a/src/commands/cem_register.ts
+++ b/src/commands/cem_register.ts
@@ -5,16 +5,22 @@ import { Message, Challenger } from '../types/slack'
 export default function() {
   app.command(`/cem_register`, async ({ payload, ack, context }) => {
     ack()
-    const body = payload
-    const challengersRef = firestore.collection(`challengers`)
     try {
-      const user = await challengersRef.doc(body.user_id).get()
+      const challengersRef = firestore.collection(`challengers`)
+      const userInfo = await app.client.users.info({
+        token: context.botToken,
+        user: payload.user_id,
+      })
+      const iconUrl = userInfo.user.profile.image_48
+      const userName = payload.text || userInfo.user.profile.display_name
+      const user = await challengersRef.doc(payload.user_id).get()
       // すでに登録されている場合
       if (user.exists) {
         await challengersRef
-          .doc(body.user_id)
+          .doc(payload.user_id)
           .update({
-            displayName: body.text || body.user_name,
+            displayName: userName,
+            iconUrl: iconUrl,
             updatedAt: FieldValue.serverTimestamp(),
           })
           .catch(err => {
@@ -22,22 +28,23 @@ export default function() {
           })
         const msg: Message = {
           token: context.botToken,
-          text: `表示名を[${body.text || body.user_name}]に変更しました`,
-          channel: body.channel_id,
-          user: body.user_id,
+          text: `表示名を[${userName}]に変更しました`,
+          channel: payload.channel_id,
+          user: payload.user_id,
         }
         return app.client.chat.postEphemeral(msg)
       }
 
       // firestoreにユーザー作成
       const challenger: Challenger = {
-        slackName: body.user_name,
-        displayName: body.text || body.user_name,
+        slackName: payload.user_name,
+        displayName: userName,
+        iconUrl: iconUrl,
         updatedAt: FieldValue.serverTimestamp(),
         createdAt: FieldValue.serverTimestamp(),
       }
       await challengersRef
-        .doc(body.user_id)
+        .doc(payload.user_id)
         .set(challenger)
         .catch(err => {
           throw new Error(err)
@@ -45,9 +52,8 @@ export default function() {
       // 成功をSlack通知
       const msg: Message = {
         token: context.botToken,
-        text: `*Here comes a new challenger!*\n挑戦者[${body.text ||
-          body.user_name}]さんを新規登録しました`,
-        channel: body.channel_id,
+        text: `*Here comes a new challenger!*\n挑戦者[${userName}]さんを新規登録しました`,
+        channel: payload.channel_id,
         icon_url: `https://challenge-every-month-404e2.appspot.com/static/boy_good.png`,
       }
       return app.client.chat.postMessage(msg).catch(err => {
@@ -58,8 +64,8 @@ export default function() {
       const msg: Message = {
         token: context.botToken,
         text: `Error: ${error}`,
-        channel: body.channel_id,
-        user: body.user_id,
+        channel: payload.channel_id,
+        user: payload.user_id,
       }
       return app.client.chat.postEphemeral(msg)
     }

--- a/src/commands/cem_review.ts
+++ b/src/commands/cem_review.ts
@@ -73,6 +73,26 @@ export default function() {
         }
         projectBlocks.push(challengeBlock)
       }
+      const reviewComment = {
+        type: `input`,
+        block_id: `review_${project.ref.id}`,
+        label: {
+          type: `plain_text`,
+          text: `レビューコメント`,
+          emoji: true,
+        },
+        optional: true,
+        element: {
+          type: `plain_text_input`,
+          multiline: true,
+          action_id: `comment`,
+          placeholder: {
+            type: `plain_text`,
+            text: `${projData.title}の振り返り`,
+          },
+        },
+      }
+      projectBlocks.push(reviewComment)
     }
     try {
       const modal = {

--- a/src/listeners/res_cem_review_all.ts
+++ b/src/listeners/res_cem_review_all.ts
@@ -4,9 +4,10 @@ import { Block, Message } from '../types/slack'
 const config = require(`config`)
 
 export default function() {
-  app.view(`cem_review`, async ({ ack, body, context }) => {
+  app.view(`cem_review`, async ({ ack, body, view, context }) => {
     ack()
-    // const payload = view.state.values
+    const payload = view.state.values
+
     const user = body.user.id
     const channel = config.get(`Slack.Channels.review`)
     // const metadata = body.view.private_metadata
@@ -47,8 +48,10 @@ export default function() {
         },
       ]
       for (const project of projects.docs) {
+        const comment = payload[`review_${project.ref.id}`].comment.value || ``
         batch.update(project.ref, {
           status: `reviewed`,
+          reviewComment: comment,
           updatedAt: timestamp,
         })
         let projectText = ``
@@ -71,7 +74,8 @@ export default function() {
           }
           projectText += `${icon} ${chalData.name}\n`
         }
-        projectText += `${projData.description}`
+        // projectText += `${projData.description}`
+        projectText += comment
         blocks.push({
           type: `section`,
           text: {

--- a/src/listeners/res_cem_review_all.ts
+++ b/src/listeners/res_cem_review_all.ts
@@ -36,6 +36,7 @@ export default function() {
       }
       const challenger = await challengerRef.get()
       const challengerName = challenger.data()!.displayName
+      const iconUrl = challenger.data()!.iconUrl
       const blocks: Block[] = [
         {
           type: `section`,
@@ -88,6 +89,8 @@ export default function() {
         },
         blocks: blocks,
         channel: channel,
+        username: challengerName,
+        icon_url: iconUrl,
       }
       return app.client.chat.postMessage(msg).catch(err => {
         throw new Error(err)

--- a/src/types/slack.ts
+++ b/src/types/slack.ts
@@ -59,6 +59,7 @@ export interface Message {
 export interface Challenger {
   slackName: string
   displayName: string
+  iconUrl: string
   updatedAt: any
   createdAt: any
 }


### PR DESCRIPTION
## 概要
/cem_publish
/cem_review
においてメッセージの発言者がAppのままだと誰のものかわかりにくいので
かわりにコマンドを実行した挑戦者のものを使用するように実装

またレビュー時にプロジェクトごとにコメントを追加できるように実装

## 変更内容
+ /cem_register: 実行時にアイコンをデータを格納
+ /cem_publish: 実行時に格納されたアイコンデータと名前を使用
+ /cem_review: モーダルにコメント欄の追加
    + 処理時にアイコンデータと名前を使用、コメントの格納

## 動作要件
すでに登録された挑戦者も再度`/cem_regiser`が必要

## リリース手順
+ [x] masterにマージする

## 実行したテスト
+ [x] CI（リント+自動テスト）
+ [x] 開発環境経由での動作確認