### PR TITLE
特別な月でメッセージを変える

### DIFF
--- a/src/requests/remind.ts
+++ b/src/requests/remind.ts
@@ -9,19 +9,28 @@ export default function() {
     const channels = config.get(`Slack.Channels`)
     const now = new Date()
     const today = now.getDate()
+    const thisMonth = now.getMonth() + 1
     const tommorrow = new Date(now.setDate(today + 1)).getDate()
 
     let text = ``
     let channel = ``
     let postingMsg = true
     if (today === 1) {
-      text = `新しい月の始まりです！今月も目標を立てて一歩一歩行きましょう！Let's Challenge！`
+      if (thisMonth === 1) {
+        text = `謹賀新年！新しい年の始まりです。今年はどんな年にしましょうか？\n今月の目標とは別に今年の目標も立てちゃいます？\nそれでは今年も、Let's Challenge！`
+      } else {
+        text = `新しい月の始まりです！今月も目標を立てて一歩一歩行きましょう！Let's Challenge！`
+      }
       channel = channels.publish
     } else if (today === 15) {
       text = `月の真ん中、折り返し地点ですね。軽く振り返ってみましょうか。進捗どうですか？`
       channel = channels.progress
     } else if (tommorrow === 1) {
-      text = `今月もお疲れさまでした。振り返りをしましょう！`
+      if (thisMonth === 12) {
+        text = `今月も、そして今年も一年お疲れさまでした。\n今年が終わる前に月の振りかえりを忘れずに！\nそして今年一年をとおしてたふりかえりをしてみてはいかがでしょうか？`
+      } else {
+        text = `今月もお疲れさまでした。振り返りをしましょう！`
+      }
       channel = channels.review
     } else {
       postingMsg = false


### PR DESCRIPTION
## 概要
remindで特別な月によってメッセージを変える

## 変更内容
remind内で当月を判定し、特別な月の場合メッセージを特別なものにしました

## 影響範囲や破壊的変更

## 動作要件
<!-- 動作に必要なコミットに含まれない変更（e.g. 環境変数、DBの更新 など）-->

## リリース手順
+ [x] masterにマージする

## 実行したテスト
+ [x] CI（リント+自動テスト）
+ [ ] 開発環境経由での動作確認

## 補足
<!-- レビューやローカル環境で試す際の注意点など -->
間に合わせの手抜きコードなのでそのうちリファクタしたい