### PR TITLE
既に登録済みのユーザーが新規登録になってしまう問題の修正

### DIFF
--- a/src/commands/cem_register.ts
+++ b/src/commands/cem_register.ts
@@ -25,6 +25,13 @@ app.command(`/cem_register`, async ({ payload, ack, context }) => {
         .catch(err => {
           throw new Error(err)
         })
+      const msg: Message = {
+        token: context.botToken,
+        text: `表示名を[${userName}]に変更しました`,
+        channel: payload.channel_id,
+        user: payload.user_id,
+      }
+      return app.client.chat.postEphemeral(msg as any)
     }
     // firestoreにユーザー作成
     const challenger: Challenger = {


### PR DESCRIPTION
## 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
既に登録済みのユーザーでも`/cem_register`すると
新規登録扱いになってしまい関連データも初期化されてしまう問題の修正


## 変更内容
#49 で削除してしまってた`/cem_register`時に
既に登録されているユーザーの場合、名前とアイコンを変更するだけにする実装を復帰。

## 影響範囲や破壊的変更

## 動作要件
<!-- 動作に必要なコミットに含まれない変更（e.g. 環境変数、DBの更新 など）-->

## リリース手順
+ [ ] masterにマージする

## 実行したテスト
+ [ ] CI（リント+自動テスト）
+ [ ] 開発環境経由での動作確認

## 補足
<!-- レビューやローカル環境で試す際の注意点など -->
